### PR TITLE
Error handling for jshint's output parsing and more verbose logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     }
   ],
   "require": {
-    "php": ">= 7.1"
+    "php": ">= 7.1",
+    "ext-libxml": "*",
+    "ext-simplexml": "*"
   },
   "require-dev": {
     "phing/phing": "3.0.x-dev"


### PR DESCRIPTION
In some cases jshint (nodejs) crashed, output is empty or contains broken xml, now this case handled as exception (instead of "no errors detected").

Also more verbosity logging added.