### PR TITLE
fix: avoid parser error : internal error: Huge input lookup

### DIFF
--- a/src/JsHintTask.php
+++ b/src/JsHintTask.php
@@ -224,7 +224,7 @@ class JsHintTask extends Task
 
         libxml_clear_errors();
         libxml_use_internal_errors(true);
-        $xml = simplexml_load_string($output);
+        $xml = simplexml_load_string($output, 'SimpleXMLElement', LIBXML_PARSEHUGE);
         if (false === $xml) {
             $errors = libxml_get_errors();
             if (!empty($errors)) {


### PR DESCRIPTION
On huge jshint's report `simplexml_load_string` failed with `PHP Warning internal error: Huge input lookup` (but `libxml_get_errors` still return empty result...).

This patch remove libxml's internal limits for the maximum size of a single text node.